### PR TITLE
updates to intersection identification

### DIFF
--- a/lib/street_address.rb
+++ b/lib/street_address.rb
@@ -852,7 +852,7 @@ module StreetAddress
       end
 
       def intersection?
-        !street2.nil?
+        !!street && !!street2
       end
 
       def line1(s = "")
@@ -867,7 +867,7 @@ module StreetAddress
           s += " " + street_type2 unless street_type2.nil?
           s += " " + suffix2 unless suffix2.nil?
         else
-          s += number
+          s += number unless number.nil?
           s += " " + prefix unless prefix.nil?
           s += " " + street unless street.nil?
           s += " " + street_type unless street_type.nil?
@@ -880,7 +880,7 @@ module StreetAddress
           s += " " + suffix unless suffix.nil?
         end
 
-        return s
+        s.strip
       end
 
       def to_s(format = :default)

--- a/lib/street_address.rb
+++ b/lib/street_address.rb
@@ -64,7 +64,7 @@
 
 module StreetAddress
   class US
-    VERSION = '1.0.6'
+    VERSION = '1.0.7'.freeze
     DIRECTIONAL = {
       "north" => "N",
       "northeast" => "NE",

--- a/test/test_street_address.rb
+++ b/test/test_street_address.rb
@@ -12,6 +12,7 @@ class StreetAddressUsTest < Test::Unit::TestCase
     @addr6 = "2730 S Veitch St #207, Arlington, VA 22206"
     @addr7 = "W298N408 Kings Way Delafield, WI 53188"
     @addr8 = "N4785 19th Avenue, Montello, WI 53949"
+    @addr9 = 'Lot 55w & 56w Long Rifle Rd, Sevierville, TN 37862'
 
     @int1 = "Hollywood & Vine, Los Angeles, CA"
     @int2 = "Hollywood Blvd and Vine St, Los Angeles, CA"
@@ -138,6 +139,17 @@ class StreetAddressUsTest < Test::Unit::TestCase
     assert_equal addr.city, 'Montello'
     assert_equal addr.state, 'WI'
     assert_equal addr.postal_code, '53949'
+
+    # not a perfect parse, but this asserts not getting wrong data or an error
+    addr = StreetAddress::US.parse(@addr9)
+    assert_equal addr.line1, ''
+    assert_equal addr.number, nil
+    assert_equal addr.street, nil
+    assert_equal addr.street_type, nil
+    assert_equal addr.city, 'Sevierville'
+    assert_equal addr.state, 'TN'
+    assert_equal addr.postal_code, '37862'
+    assert_equal addr.intersection?, false
 
     addr = StreetAddress::US.parse(@int1)
     assert_equal addr.city, "Los Angeles"


### PR DESCRIPTION
## Purpose
Causing this failure in `promote`
https://app.bugsnag.com/adwerx/promote/errors/60141604e804d60018ebbe3e

The address `Lot 55w & 56w Long Rifle Rd, Sevierville, TN 37862, US` was getting identified as an intersection, but had no `street` in the parsed output:
```
{
          "street" => nil,
     "street_type" => nil,
          "suffix" => nil,
          "prefix" => nil,
            "city" => "Sevierville",
           "state" => "TN",
     "postal_code" => "37862",
         "street2" => "56w Long Rifle",
    "street_type2" => "Rd",
         "suffix2" => nil,
         "prefix2" => nil
}
```
Because it _did_ have a `street2`, though, it was getting identified as an intersection, but when asking for `line1` the code there was trying to do essentially `'' += nil` since `street` was `nil`.

# Approach
For that reason, the check if a parsed address is an intersection will look at the presence of both `street` _and_ `street2`. I added a test case and was able to run the tests with `rake test` to catch a few other finicky things. The address itself won't parse perfectly-- not finding the street name, but unless I want to get into the regex there (I don't), I think just ensuring this doesn't error is good enough for now.